### PR TITLE
Support for both INNER JOIN and LEFT JOIN

### DIFF
--- a/Field/Entity.php
+++ b/Field/Entity.php
@@ -36,6 +36,11 @@ class Entity extends AbstractField
      */
     protected $relations = array();
 
+    /**
+     * @var string Join type
+     */
+    protected $joinType;
+
     public static function generateAlias($name)
     {
         if (!$name) {
@@ -60,6 +65,24 @@ class Entity extends AbstractField
         $this->alias = $alias;
 
         return $this;
+    }
+
+    /**
+     * @param string $joinType
+     */
+    public function setJoinType($joinType)
+    {
+        $this->joinType = $joinType;
+
+        return $this;
+    }
+
+    /**
+     * @return string $joinType
+     */
+    public function getJoinType()
+    {
+        return $this->joinType;
     }
 
     /**
@@ -150,16 +173,18 @@ class Entity extends AbstractField
         $qb->addSelect($this->getAlias());
     }
 
-    public function join($name, $alias)
+    public function join($name, $alias, $type = 'LEFT')
     {
         if (!isset($this->relations[$name])) {
             if ($child = $this->getTable()->getEntity($alias)) {
                 $this->relations[$name] = $child;
+                $child->setJoinType($type);
 
                 return $child;
             } else {
                 $child = new self($this->getTable(), $name, $alias);
                 $child->setParent($this);
+                $child->setJoinType($type);
                 $this->relations[$name] =  $child;
             }
         }

--- a/Table.php
+++ b/Table.php
@@ -257,7 +257,14 @@ class Table extends Entity
     {
         foreach ($this->entities as $entity) {
             if ($entity != $this) {
-                $qb->leftJoin($entity->getFullName(), $entity->getAlias());
+                switch ($entity->getJoinType()) {
+                    case 'LEFT':
+                        $qb->leftJoin($entity->getFullName(), $entity->getAlias());
+                        break;
+                    case 'INNER':
+                        $qb->innerJoin($entity->getFullName(), $entity->getAlias());
+                        break;
+                }
             }
         }
         return $this;

--- a/TableBuilder.php
+++ b/TableBuilder.php
@@ -143,6 +143,25 @@ class TableBuilder
 
     public function join($fullName, $alias)
     {
+        return $this->leftJoin($fullName, $alias);
+    }
+
+    public function leftJoin($fullName, $alias)
+    {
+        $this->_join($fullName, $alias, 'LEFT');
+
+        return $this;
+    }
+
+    public function innerJoin($fullName, $alias)
+    {
+        $this->_join($fullName, $alias, 'INNER');
+
+        return $this;
+    }
+
+    private function _join($fullName, $alias, $type)
+    {
         if (null !== $this->table->getIndex()) {
             $index = $this->getTable()->getIndex();
         } else {
@@ -154,7 +173,7 @@ class TableBuilder
         if (!$parent) {
             throw new \Exception("Parent entity not found for " . $fullName);
         }
-        $parent->join($name, $alias);
+        $parent->join($name, $alias, $type);
 
         return $this;
     }


### PR DESCRIPTION
Eg:

```
$builder
    ->from('FooBundle:Message', 'm')
    ->innerJoin('m.conversation', 'c')
    ->leftJoin('m.senderUser', 'su')
    ->leftJoin('m.senderGuest', 'sg')
```

Legacy join method still works

```
$builder
    ->from('FooBundle:Message', 'm')
    ->join('m.conversation', 'c')
    ->join('m.senderUser', 'su')
    ->join('m.senderGuest', 'sg')
```

will give LEFT JOINS as before.
