### PR TITLE
typehint NumberField search parameter as float for correct SQL syntax

### DIFF
--- a/Field/NumberField.php
+++ b/Field/NumberField.php
@@ -14,7 +14,7 @@ class NumberField extends RangeField
                 $expr->add(
                     $qb->expr()->eq($field, ':'.$var)
                 );
-                $qb->setParameter($var, $this->getSearch());
+                $qb->setParameter($var, (float) $this->getSearch());
             }
         } else {
             $expr = parent::filter($qb);


### PR DESCRIPTION
With

```
$builder
    ->add('number', 'table_alias.id')
```

Filtering on that row produced this SQL:

```
WHERE table.id = '999'
```

Now:

```
WHERE table.id = 999
```
